### PR TITLE
Fix placeholder sync with preformatted messages

### DIFF
--- a/socialismus-adapter-config/src/main/java/me/whereareiam/socialismus/adapter/config/template/chat/ChatSettingsTemplate.java
+++ b/socialismus-adapter-config/src/main/java/me/whereareiam/socialismus/adapter/config/template/chat/ChatSettingsTemplate.java
@@ -30,10 +30,11 @@ public class ChatSettingsTemplate implements DefaultConfig<ChatSettings> {
 
 		chatSettings.setHistory(history);
 
-		ChatSettings.SynchronizationSettings synchronization = new ChatSettings.SynchronizationSettings();
-		synchronization.setEnabled(false);
+                ChatSettings.SynchronizationSettings synchronization = new ChatSettings.SynchronizationSettings();
+                synchronization.setEnabled(false);
+                synchronization.setPreFormatMessages(false);
 
-		chatSettings.setSynchronization(synchronization);
+                chatSettings.setSynchronization(synchronization);
 
 		return chatSettings;
 	}

--- a/socialismus-common-api/src/main/java/me/whereareiam/socialismus/api/model/chat/ChatSettings.java
+++ b/socialismus-common-api/src/main/java/me/whereareiam/socialismus/api/model/chat/ChatSettings.java
@@ -101,11 +101,18 @@ public class ChatSettings {
 		private String bypassPermission;
 	}
 
-	@Getter
-	@Setter
-	@ToString
-	public static class SynchronizationSettings {
-		private boolean enabled;
-		private boolean clearHistory;
-	}
+        @Getter
+        @Setter
+        @ToString
+        public static class SynchronizationSettings {
+                private boolean enabled;
+                private boolean clearHistory;
+                /**
+                 * When enabled, chat messages are fully formatted on the origin
+                 * server before being synchronized. This allows placeholder
+                 * integrations that rely on the sender being present to work
+                 * correctly on other servers.
+                 */
+                private boolean preFormatMessages;
+        }
 }

--- a/socialismus-common/src/main/java/me/whereareiam/socialismus/common/sync/ChatNetworkBridge.java
+++ b/socialismus-common/src/main/java/me/whereareiam/socialismus/common/sync/ChatNetworkBridge.java
@@ -9,10 +9,13 @@ import me.whereareiam.socialismus.api.Logger;
 import me.whereareiam.socialismus.api.input.sync.ChatSyncBus;
 import me.whereareiam.socialismus.api.model.chat.ChatSettings;
 import me.whereareiam.socialismus.api.model.chat.message.ChatMessage;
+import me.whereareiam.socialismus.api.model.chat.message.FormattedChatMessage;
 import me.whereareiam.socialismus.api.output.PlatformInteractor;
 import me.whereareiam.socialismus.api.output.SerializationService;
 import me.whereareiam.socialismus.api.output.resource.sync.SyncService;
 import me.whereareiam.socialismus.common.chat.ChatCoordinator;
+import me.whereareiam.socialismus.common.chat.broadcast.ChatBroadcaster;
+import me.whereareiam.socialismus.api.input.container.ChatHistoryContainerService;
 
 import java.util.Set;
 
@@ -21,12 +24,14 @@ import java.util.Set;
 public class ChatNetworkBridge implements ChatSyncBus {
 	private static final String CHANNEL = Constants.Channels.CHAT;
 
-	private final SyncService sync;
-	private final SerializationService serializationService;
-	private final ChatCoordinator coordinator;
-	private final PlatformInteractor platformInteractor;
+        private final SyncService sync;
+        private final SerializationService serializationService;
+        private final ChatCoordinator coordinator;
+        private final PlatformInteractor platformInteractor;
+        private final ChatBroadcaster broadcaster;
+        private final ChatHistoryContainerService historyContainer;
 
-	private final Provider<ChatSettings> chatSettings;
+        private final Provider<ChatSettings> chatSettings;
 
 	public void initialize() {
 		if (!chatSettings.get().getSynchronization().isEnabled())
@@ -60,18 +65,32 @@ public class ChatNetworkBridge implements ChatSyncBus {
 	}
 
 	private void handleEvent(byte[] payload) {
-		try {
-			ChatMessage chatMessage = serializationService.deserialize(payload, ChatMessage.class);
+                try {
+                        if (chatSettings.get().getSynchronization().isPreFormatMessages()) {
+                                FormattedChatMessage formatted = serializationService.deserialize(payload, FormattedChatMessage.class);
 
-			if (Constants.IDENTIFIER.equals(chatMessage.getOrigin())) return;
+                                if (Constants.IDENTIFIER.equals(formatted.getOrigin())) return;
 
-			chatMessage.setRecipients(Set.of());
-			chatMessage.getSender().setInteractor(platformInteractor);
+                                formatted.setRecipients(Set.of());
+                                formatted.getSender().setInteractor(platformInteractor);
 
-			Logger.debug("Received chat message from sync channel: " + chatMessage.getId());
-			coordinator.coordinate(chatMessage);
-		} catch (Exception ex) {
-			Logger.warn("Bad chat-sync packet: " + ex);
-		}
+                                Logger.debug("Received formatted chat message from sync channel: " + formatted.getId());
+                                broadcaster.broadcast(formatted);
+                                historyContainer.addMessage(formatted.getId(), formatted);
+                                return;
+                        }
+
+                        ChatMessage chatMessage = serializationService.deserialize(payload, ChatMessage.class);
+
+                        if (Constants.IDENTIFIER.equals(chatMessage.getOrigin())) return;
+
+                        chatMessage.setRecipients(Set.of());
+                        chatMessage.getSender().setInteractor(platformInteractor);
+
+                        Logger.debug("Received chat message from sync channel: " + chatMessage.getId());
+                        coordinator.coordinate(chatMessage);
+                } catch (Exception ex) {
+                        Logger.warn("Bad chat-sync packet: " + ex);
+                }
 	}
 }

--- a/socialismus-platform/platform-bukkit/paper/src/main/java/me/whereareiam/socialismus/platform/paper/listener/chat/PlayerChatListener.java
+++ b/socialismus-platform/platform-bukkit/paper/src/main/java/me/whereareiam/socialismus/platform/paper/listener/chat/PlayerChatListener.java
@@ -5,6 +5,7 @@ import com.google.inject.Singleton;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import lombok.RequiredArgsConstructor;
 import me.whereareiam.socialismus.api.input.sync.ChatSyncBus;
+import me.whereareiam.socialismus.api.model.chat.ChatSettings;
 import me.whereareiam.socialismus.api.model.chat.message.ChatMessage;
 import me.whereareiam.socialismus.api.model.chat.message.FormattedChatMessage;
 import me.whereareiam.socialismus.api.output.listener.DynamicListener;
@@ -12,6 +13,7 @@ import me.whereareiam.socialismus.common.chat.ChatCoordinator;
 import me.whereareiam.socialismus.common.chat.ChatMessageFactory;
 import me.whereareiam.socialismus.common.chat.broadcast.ChatBroadcaster;
 import me.whereareiam.socialismus.platform.paper.renderer.SocialismusRenderer;
+import com.google.inject.Provider;
 import net.kyori.adventure.audience.Audience;
 import org.bukkit.entity.Player;
 
@@ -23,10 +25,11 @@ import java.util.stream.Collectors;
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = {@Inject})
 public class PlayerChatListener implements DynamicListener<AsyncChatEvent> {
-	private final ChatSyncBus chatSyncBus;
-	private final ChatCoordinator chatCoordinator;
-	private final ChatMessageFactory chatMessageFactory;
-	private final ChatBroadcaster chatBroadcaster;
+        private final ChatSyncBus chatSyncBus;
+        private final ChatCoordinator chatCoordinator;
+        private final ChatMessageFactory chatMessageFactory;
+        private final ChatBroadcaster chatBroadcaster;
+        private final Provider<ChatSettings> chatSettings;
 
 	@Override
 	public void onEvent(AsyncChatEvent event) {
@@ -40,14 +43,19 @@ public class PlayerChatListener implements DynamicListener<AsyncChatEvent> {
 				.map(aud -> ((Player) aud).getUniqueId())
 				.collect(Collectors.toSet());
 
-		ChatMessage chatMessage = chatMessageFactory.createChatMessage(
-				sender.getUniqueId(),
-				playerRecipientUuids,
-				event.message()
-		);
-		chatSyncBus.publish(chatMessage);
+                ChatMessage chatMessage = chatMessageFactory.createChatMessage(
+                                sender.getUniqueId(),
+                                playerRecipientUuids,
+                                event.message()
+                );
 
-		FormattedChatMessage formatted = chatCoordinator.coordinate(chatMessage);
+                FormattedChatMessage formatted = chatCoordinator.coordinate(chatMessage);
+
+                if (chatSettings.get().getSynchronization().isPreFormatMessages()) {
+                        chatSyncBus.publish(formatted);
+                } else {
+                        chatSyncBus.publish(chatMessage);
+                }
 		if (formatted == null
 				|| formatted.isCancelled()
 				|| !formatted.isVanillaSending()) {


### PR DESCRIPTION
## Summary
- add `preFormatMessages` option for chat sync settings
- support publishing preformatted messages
- broadcast formatted messages on receiving servers
- allow paper listener to publish formatted messages when enabled

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6878f6b2c7488323b6ee56ad0615e026