### PR TITLE
Platform: Resolve Paper 26.1+ server version format

### DIFF
--- a/socialismus-api/src/main/java/me/whereareiam/socialismus/type/Version.java
+++ b/socialismus-api/src/main/java/me/whereareiam/socialismus/type/Version.java
@@ -73,41 +73,67 @@ public enum Version {
 	public static Version of(String version) {
 		if (version == null || version.isEmpty()) return Version.UNSUPPORTED;
 
-		String normalizedVersion = version.split("[\\s-]")[0];
+		// Extract the leading numeric version components, ignoring revision/build
+		// suffixes such as "-R0.1-SNAPSHOT" (Spigot/Bukkit) or ".build.63-stable"
+		// (Paper's 26.1+ versioning scheme). For example,
+		// "26.1.2.build.63-stable" -> [26, 1, 2].
+		int[] currentParts = leadingNumericComponents(version.split("[\\s-]")[0]);
+		if (currentParts.length == 0) return Version.UNSUPPORTED;
+
+		StringBuilder name = new StringBuilder("V");
+		for (int part : currentParts) {
+			name.append("_").append(part);
+		}
 
 		try {
-			return Version.valueOf("V_" + normalizedVersion.replace(".", "_"));
+			return Version.valueOf(name.toString());
 		} catch (IllegalArgumentException e) {
 			Version latest = getLatest();
 			if (latest == UNSUPPORTED) {
 				return UNSUPPORTED;
 			}
 
-			String[] latestVersionParts = latest.name().substring(2).split("_");
-			String[] currentVersionParts = normalizedVersion.split("\\.");
+			int[] latestParts = versionComponents(latest);
 
-			int minLength = Math.min(latestVersionParts.length, currentVersionParts.length);
+			int minLength = Math.min(latestParts.length, currentParts.length);
 			for (int i = 0; i < minLength; i++) {
-				try {
-					int latestPart = Integer.parseInt(latestVersionParts[i]);
-					int currentPart = Integer.parseInt(currentVersionParts[i]);
-
-					if (currentPart > latestPart) {
-						return FUTURE;
-					} else if (currentPart < latestPart) {
-						return UNSUPPORTED;
-					}
-				} catch (NumberFormatException ex) {
+				if (currentParts[i] > latestParts[i]) {
+					return FUTURE;
+				} else if (currentParts[i] < latestParts[i]) {
 					return UNSUPPORTED;
 				}
 			}
 
-			if (currentVersionParts.length > latestVersionParts.length) {
+			if (currentParts.length > latestParts.length) {
 				return FUTURE;
 			}
 
 			return UNSUPPORTED;
 		}
+	}
+
+	/**
+	 * Extracts the leading run of numeric, dot-separated components from a raw
+	 * version token, stopping at the first non-numeric segment. This strips
+	 * build/revision suffixes (e.g. Paper's "26.1.2.build.63") so the underlying
+	 * Minecraft version can be matched.
+	 *
+	 * @param version the raw version token (already trimmed of "-"/whitespace tails)
+	 * @return the leading numeric components, or an empty array if none are present
+	 */
+	private static int[] leadingNumericComponents(String version) {
+		String[] parts = version.split("\\.");
+		int count = 0;
+		while (count < parts.length && parts[count].matches("\\d+")) {
+			count++;
+		}
+
+		int[] result = new int[count];
+		for (int i = 0; i < count; i++) {
+			result[i] = Integer.parseInt(parts[i]);
+		}
+
+		return result;
 	}
 
 	/**

--- a/socialismus-common/src/test/java/me/whereareiam/socialismus/common/VersionTest.java
+++ b/socialismus-common/src/test/java/me/whereareiam/socialismus/common/VersionTest.java
@@ -32,6 +32,18 @@ class VersionTest {
 	}
 
 	@Test
+	@DisplayName("Should strip Bukkit/Paper build suffixes when resolving versions")
+	void ofStripsServerBuildSuffixes() {
+		// Paper 26.1+ getBukkitVersion(), e.g. "26.1.2.build.63-stable"
+		assertEquals(Version.V_26_1_2, Version.of("26.1.2.build.63-stable"));
+		// Legacy Spigot/Bukkit getBukkitVersion() format
+		assertEquals(Version.V_1_21_4, Version.of("1.21.4-R0.1-SNAPSHOT"));
+		assertEquals(Version.V_26_1, Version.of("26.1.build.1-stable"));
+		// A genuinely newer release with a build suffix is still in the future
+		assertEquals(Version.FUTURE, Version.of("26.1.3.build.1-stable"));
+	}
+
+	@Test
 	@DisplayName("Future versions should compare higher than supported releases")
 	void futureVersionsCompareAboveSupportedVersions() {
 		assertTrue(Version.isHigherThan(Version.FUTURE, Version.V_1_20_6));


### PR DESCRIPTION
## Problem

On Paper 26.1+, `Bukkit.getBukkitVersion()` returns `26.1.2.build.63-stable` instead of the legacy `1.21.4-R0.1-SNAPSHOT` form ([PaperMC/Paper#13885](https://github.com/PaperMC/Paper/issues/13885), marked "works as intended").

`Version.of()` split the string only on `[\s-]`, so the `.build.63` tail survived: `valueOf("V_26_1_2_build_63")` fails, and the numeric fallback counts 5 components against the latest's 3 and returns `FUTURE`. As a result `ModuleVersionResolver` rejects **every** module on 26.1.2:

```
[Socialismus] Module Bubbler does not support version FUTURE
```

## Fix

Parse only the leading numeric version components (`leadingNumericComponents`), dropping build/revision suffixes:

| Input | Result |
|---|---|
| `26.1.2.build.63-stable` | `V_26_1_2` |
| `1.21.4-R0.1-SNAPSHOT` | `V_1_21_4` (legacy format still works) |
| `26.1.3.build.1-stable` | `FUTURE` (genuinely newer stays future) |

The numeric fallback now reuses `versionComponents(...)`.

## Tests

Added `VersionTest.ofStripsServerBuildSuffixes`; full `VersionTest` passes (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)